### PR TITLE
:building_construction: Update NDK version to 27.0.12077973

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = "com.IamPekka058.debbydebs"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
This pull request updates the Android build configuration to specify a fixed version of the NDK.

* [`android/app/build.gradle.kts`](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL14-R14): Updated the `ndkVersion` from `flutter.ndkVersion` to a specific version, `"27.0.12077973"`, to ensure consistent builds across environments.