### PR TITLE
:bug: Fix dropdown initialization

### DIFF
--- a/lib/ui/forms/debt_creation/debt_creation_screen.dart
+++ b/lib/ui/forms/debt_creation/debt_creation_screen.dart
@@ -102,7 +102,7 @@ class DebtCreationScreen extends StatelessWidget {
                               border: OutlineInputBorder(),
                             ),
                             hint: const Text("Select a friend who owes you"),
-                            value: model.selectedContact,
+                            initialValue: model.selectedContact,
                             items: model.contacts,
                             onChanged: model.selectContact,
                           ),


### PR DESCRIPTION
This pull request introduces a minor update to the contact selection field in the `DebtCreationScreen`. The change improves the initialization of the selected contact value in the dropdown.

* UI improvement: The dropdown field now uses `initialValue` instead of `value` to set the selected contact, which is more idiomatic for form initialization in Flutter. (`lib/ui/forms/debt_creation/debt_creation_screen.dart`)